### PR TITLE
ES6 syntax, comments, listen for tab creation/tab moved from window, GUID for XPI loading

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Tuomas Salo
+Copyright (c) 2020 Austin Moore
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -23,7 +23,4 @@ This extension writes the tab number to the first eight tabs, the ones accessibl
 ## Known issues
 
 - does not add numbers to pinned tabs, internal error pages, "new tab" pages or other special tabs
-
-- does not keep in sync when dragging tabs to/from another window
-
 - will mess up with titles already starting with the characters `¹`...`⁸`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,12 @@
 {
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{d4004003-765f-477d-be7b-0b15ff761585}"
+    }
+  },
   "name": "Tab Numbering",
   "description": "This extension writes the tab number to the first eight tabs, the ones accessible with ctrl/cmd + number",
-  "version" : "0.1.1",
+  "version" : "1.0.0",
   "permissions": [
     "tabs", "http://*/*", "https://*/*"
   ],

--- a/tab-numbering.js
+++ b/tab-numbering.js
@@ -5,6 +5,8 @@
  * Contributions by:  Austin Moore
  */
 
+'use strict';
+
 const browser = window.browser || window.chrome;
 
 /*

--- a/tab-numbering.js
+++ b/tab-numbering.js
@@ -62,6 +62,9 @@ const updateAll = () => {
 // Must listen for opening anchors in new tabs
 browser.tabs.onCreated.addListener(updateAll);
 
+// Must listen for tabs being attached from other windows
+browser.tabs.onAttached.addListener(updateAll);
+
 browser.tabs.onMoved.addListener(updateAll);
 
 // Firefox seems to do this inconsistently, thus this setTimeout kludge

--- a/tab-numbering.js
+++ b/tab-numbering.js
@@ -65,16 +65,26 @@ browser.tabs.onCreated.addListener(updateAll);
 // Must listen for tabs being attached from other windows
 browser.tabs.onAttached.addListener(updateAll);
 
+// Must listen for tabs being moved
 browser.tabs.onMoved.addListener(updateAll);
 
-// Firefox seems to do this inconsistently, thus this setTimeout kludge
-browser.tabs.onRemoved.addListener(() => {
-  updateAll();
-  setTimeout(updateAll, 100);
-  setTimeout(updateAll, 500);
-  setTimeout(updateAll, 1000);
+// Must listen for tabs being removed
+browser.tabs.onRemoved.addListener((tabId, removeInfo) => {
+   /* Check that the tab has been removed every 300ms.
+      Firefox fires onRemoved BEFORE it removes the tab */
+  const checkTabRemoval = () => {
+    browser.tabs.query({}, tabs => {
+      if (tabs.filter(tab => tab.id === tabId).length === 0)
+        updateAll();
+      else
+        setTimeout(checkTabRemoval, 300);
+    });
+  };
+
+  checkTabRemoval();
 });
 
+// Must listen for tab updates
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   update(tab);
 });

--- a/tab-numbering.js
+++ b/tab-numbering.js
@@ -23,13 +23,19 @@ const update = tab => {
   if (!newTitle)
     return;
 
-  const numbers = ['¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸'];
+  const numbers = ['¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'];
 
   // Take out one of these numbers if it already exists in the title
   if (numbers.includes(newTitle[0]))
     newTitle = newTitle.substring(1);
 
-  if (tab.index < 8)
+  let tabCount = 9;
+
+  // If we are using Firefox
+  if (browser === window.browser)
+    tabCount = 8;
+
+  if (tab.index < tabCount)
     newTitle = numbers[tab.index] + newTitle;
 
   if (oldTitle !== newTitle) {
@@ -70,14 +76,14 @@ browser.tabs.onMoved.addListener(updateAll);
 
 // Must listen for tabs being removed
 browser.tabs.onRemoved.addListener((tabId, removeInfo) => {
-   /* Check that the tab has been removed every 300ms.
+   /* Check that the tab has been removed every 100ms
       Firefox fires onRemoved BEFORE it removes the tab */
   const checkTabRemoval = () => {
     browser.tabs.query({}, tabs => {
       if (tabs.filter(tab => tab.id === tabId).length === 0)
         updateAll();
       else
-        setTimeout(checkTabRemoval, 300);
+        setTimeout(checkTabRemoval, 100);
     });
   };
 


### PR DESCRIPTION
## Fixes
- Now changes tab number when dragged from another window.
- Now changes tab number when a link is opened in a new window and inserted between other tabs.
- It is no longer possible for tab numbers not to update on a tab removal.

## Additions
- Added a randomly generated GUID so the extension can be archived to XPI and loaded in Firefox Developer Edition/Nightly. This will cause an error to appear in Chrome but not function any differently.
- Using strict mode

## Changes
- Using ES6 syntax (arrow notation, let, const)
- More comments to code