### PR TITLE
Update all tabs when a new tab is created

### DIFF
--- a/tab-numbering.js
+++ b/tab-numbering.js
@@ -49,5 +49,8 @@ browser.tabs.onRemoved.addListener(() => {
 browser.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
   update(tab)
 })
+browser.tabs.onCreated.addListener(() => {
+  updateAll()
+})
 
 updateAll()


### PR DESCRIPTION
When using Ctrl+Click on a link, for example, a new tab can be created in front of existing tabs. This ensures that the numbering of the existing tabs gets updated accordingly.

Thanks for creating this addon!